### PR TITLE
fix aws course link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Contributions welcome!
 
 ## Courses
 
-- [Building Event-Driven Applications with Amazon EventBridge]([https://t.co/4sHTGW3h26](https://explore.skillbuilder.aws/learn/course/15018/Building%2520Event-Driven%2520Applications%2520With%2520Amazon%2520EventBridge%2520%28Amazon%29)) - Free training provided by AWS, if you are new to EventBridge or want to learn more this is worth taking
+- [Building Event-Driven Applications with Amazon EventBridge](https://explore.skillbuilder.aws/learn/course/internal/view/elearning/15008/building-event-driven-applications-with-amazon-eventbridge) - Free training provided by AWS, if you are new to EventBridge or want to learn more this is worth taking
 
 ## Patterns
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Contributions welcome!
 
 ## Courses
 
-- [Building Event-Driven Applications with Amazon EventBridge](https://explore.skillbuilder.aws/learn/course/internal/view/elearning/15008/building-event-driven-applications-with-amazon-eventbridge) - Free training provided by AWS, if you are new to EventBridge or want to learn more this is worth taking
+- [Building Event-Driven Applications with Amazon EventBridge](https://explore.skillbuilder.aws/learn/course/external/view/elearning/15008/building-event-driven-applications-with-amazon-eventbridge) - Free training provided by AWS, if you are new to EventBridge or want to learn more this is worth taking
 
 ## Patterns
 


### PR DESCRIPTION
new skill builder link to building event-driven free course,

there's two links for it,

1. internal link requires the user to login:
https://explore.skillbuilder.aws/learn/course/internal/view/elearning/15008/building-event-driven-applications-with-amazon-eventbridge

2. external link shows the content without requiring login
https://explore.skillbuilder.aws/learn/course/external/view/elearning/15008/building-event-driven-applications-with-amazon-eventbridge

I'm using 2. for this PR change